### PR TITLE
fix: f-string unmatched bracket SyntaxError on Python < 3.12

### DIFF
--- a/api.py
+++ b/api.py
@@ -1200,7 +1200,7 @@ class BHYG(metaclass=ProtectedMeta):
 
         if self.config.get("ip", None) is not None:
             resp = self.client.post(
-                f"{self.order_base}/api/ticket/order/createV2?project_id={self.config["project_id"]}{'&ptoken=' + ptoken if self.config['hotProject'] else ''}",
+                f"{self.order_base}/api/ticket/order/createV2?project_id={self.config['project_id']}{'&ptoken=' + ptoken if self.config['hotProject'] else ''}",
                 ip=self.config["ip"],
                 json=data,
             )


### PR DESCRIPTION
In api.py line 1203, the f-string uses double quotes for the outer string but also uses double quotes inside the expression for dict key access. This causes SyntaxError on Python 3.11 and below.

## Fix
Changed self.config["project_id"] to self.config['project_id'] on line 1203, matching the identical expression on line 1209 which already uses single quotes.

## Impact
- Only Python < 3.12 affected (PEP 701 landed in 3.12)
- One character change, zero behavioral impact