### PR TITLE
bug-fix/buyer-id_uid_check

### DIFF
--- a/api.py
+++ b/api.py
@@ -614,10 +614,14 @@ class BHYG(metaclass=ProtectedMeta):
                 return False
             if self.client.uid is not None and self.client.uid != 0:
                 for buyer in self.config["id_buyer"]:
-                    if self.config["uid_buyer"].get(buyer["id"], None) is not None:
-                        if self.config["uid_buyer"][buyer["id"]] != self.client.uid:
+                    buyer_id = str(buyer["id"])
+                    buyer_uid = self.config["uid_buyer"].get(
+                        buyer_id, self.config["uid_buyer"].get(buyer["id"], None)
+                    )
+                    if buyer_uid is not None:
+                        if buyer_uid != self.client.uid:
                             logger.debug(
-                                f"UID mismatch: {self.config['uid_buyer'][buyer['id']]}!= {self.client.uid}"
+                                f"UID mismatch: {buyer_uid}!= {self.client.uid}"
                             )
                             logger.warning(self.i18n("buyer_uid_not_match"))
                             return False

--- a/api.py
+++ b/api.py
@@ -615,9 +615,9 @@ class BHYG(metaclass=ProtectedMeta):
             if self.client.uid is not None and self.client.uid != 0:
                 for buyer in self.config["id_buyer"]:
                     buyer_id = str(buyer["id"])
-                    buyer_uid = self.config["uid_buyer"].get(
-                        buyer_id, self.config["uid_buyer"].get(buyer["id"], None)
-                    )
+                    buyer_uid = self.config["uid_buyer"].get(buyer_id)
+                    if buyer_uid is None:
+                        buyer_uid = self.config["uid_buyer"].get(buyer["id"], None)
                     if buyer_uid is not None:
                         if buyer_uid != self.client.uid:
                             logger.debug(

--- a/main.py
+++ b/main.py
@@ -389,7 +389,7 @@ def select_buyer():
                     "id_type": buyer["id_type"],
                 }
             )
-            client.config["uid_buyer"][buyer["id"]] = buyer["uid"]
+            client.config["uid_buyer"][str(buyer["id"])] = buyer["uid"]
         logger.debug("Selected buyers: {}".format(client.config["id_buyer"]))
         if client.config.get("is_changfan", False):
             client.config["buyer"] = questionary.text(


### PR DESCRIPTION
## Summary

Fix buyer UID validation being skipped after restart or config reload.

## Problem

`uid_buyer` uses `buyer["id"]` as the key for the buyer UID mapping.

At runtime, `buyer["id"]` is an `int`, but after the config is saved to JSON and loaded again, dictionary keys are restored as `str`.

As a result, after restart or config reload, the validation logic used the integer `buyer["id"]` to look up `uid_buyer`, failed to find the saved UID, and skipped the buyer UID mismatch check.

## Changes

- Store `uid_buyer` keys as `str(buyer["id"])`
- During validation, look up the string key first
- Keep the old integer key lookup as a fallback for compatibility with existing in-memory runtime data

## Impact

This only changes the key type used by the `uid_buyer` mapping.

## Verification

- Ticket-buying workflow works and can detect `uid` mismatch.