### PR TITLE
bug-fix/reload_buyer_list_on_switching_account

### DIFF
--- a/api.py
+++ b/api.py
@@ -182,7 +182,9 @@ class BHYG(metaclass=ProtectedMeta):
             logger.error(self.i18n("canceled"))
             return
         if uid == self.i18n("qr_code"):
-            url, key = self.client.gen_qr_url()
+            new_client = BilibiliClient()
+            new_client.init_show_cookies()
+            url, key = new_client.gen_qr_url()
             if not url:
                 logger.error(self.i18n("qr_code_generate_failed"))
                 return
@@ -197,8 +199,9 @@ class BHYG(metaclass=ProtectedMeta):
             logger.info(self.i18n("qr_code_scan"))
             while True:
                 try:
-                    is_login, retry = self.client.check_qr_status(key)
+                    is_login, retry = new_client.check_qr_status(key)
                     if is_login:
+                        self.client = new_client
                         logger.success(self.i18n("qr_code_login_success"))
                         logger.debug("QR Code Login Success")
                         self.save_config()


### PR DESCRIPTION
## Summary

Fix the buyer list not refreshing after switching accounts via QR-code login.

## Problem

Before this change, the QR-code login path reused the existing client:

When QR-code login succeeds, the existing client object is not rebuilt. That means the current runtime can continue with a mixed client state: new account login cookies plus previous account runtime or show-side state.

This results in an unsuccessful reload of the buyer list.

## Changes

- Use a fresh BilibiliClient for QR-code login
- Replace old self.client only after QR-code login succeeds

## Impact

QR code login process:
This makes QR-code account switching create and use a new client object.


## Verification

- App correctly get buyer list right after login